### PR TITLE
Switch tests from Mocha to Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,11 @@
                 "@types/node": "18.7.9",
                 "@typescript-eslint/eslint-plugin": "5.34.0",
                 "@typescript-eslint/parser": "5.34.0",
-                "chai": "*",
                 "eslint": "8.22.0",
                 "eslint-plugin-jsdoc": "39.3.6",
-                "mocha": "*",
                 "pkg": "5.8.0",
-                "typescript": "4.7.4"
+                "typescript": "4.7.4",
+                "jest": "^29.0.0"
             }
         },
         "node_modules/@babel/generator": {

--- a/package.json
+++ b/package.json
@@ -51,15 +51,14 @@
         "@types/node": "18.7.11",
         "@typescript-eslint/eslint-plugin": "5.34.0",
         "@typescript-eslint/parser": "5.34.0",
-        "chai": "*",
         "eslint": "8.22.0",
         "eslint-plugin-jsdoc": "39.3.6",
         "pkg": "5.8.0",
         "typescript": "4.7.4",
-        "mocha": "*"
+        "jest": "^29.0.0"
     },
     "scripts": {
-        "test": "mocha -R min",
+        "test": "jest",
         "testsample": "node htmldiff-cli.js sample/before.html sample/after.html - -c myDiffClass -p myPrefix",
         "lint": "eslint -c eslintrc.json --parser-options=project:./tsconfig.json --ext .ts ./",
         "premake": "npm run lint",

--- a/test/calculate_operations.spec.js
+++ b/test/calculate_operations.spec.js
@@ -8,7 +8,7 @@ describe('calculateOperations', function(){
     });
 
     it('should be a function', function(){
-        expect(cut).is.a('function');
+        expect(typeof cut).toBe('function');
     });
 
     describe('Actions', function(){
@@ -21,11 +21,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should result in 3 operations', function(){
-                    expect(res.length).to.equal(3);
+                    expect(res.length).toBe(3);
                 });
 
                 it('should replace "on"', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'replace',
                         startInBefore   : 2,
                         endInBefore     : 2,
@@ -43,11 +43,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should result in 3 operations', function(){
-                    expect(res.length).to.equal(3);
+                    expect(res.length).toBe(3);
                 });
 
                 it('should show an insert for "on"', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'insert',
                         startInBefore   : 2,
                         endInBefore     : null,
@@ -64,11 +64,11 @@ describe('calculateOperations', function(){
                     });
 
                     it('should still have 3 operations', function(){
-                        expect(res.length).to.equal(3);
+                        expect(res.length).toBe(3);
                     });
 
                     it('should show a big insert', function(){
-                        expect(res[1]).eql({
+                        expect(res[1]).toEqual({
                             action          : 'insert',
                             startInBefore   : 2,
                             endInBefore     : null,
@@ -87,11 +87,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 3 operations', function(){
-                    expect(res.length).to.equal(3);
+                    expect(res.length).toBe(3);
                 });
 
                 it('should show the delete in the middle', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'delete',
                         startInBefore   : 4,
                         endInBefore     : 9,
@@ -109,8 +109,8 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return a single op', function(){
-                    expect(res.length).to.equal(1);
-                    expect(res[0]).eql({
+                    expect(res.length).toBe(1);
+                    expect(res[0]).toEqual({
                         action          : 'equal',
                         startInBefore   : 0,
                         endInBefore     : 10,
@@ -130,11 +130,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have a replace at the beginning', function(){
-                    expect(res[0]).eql({
+                    expect(res[0]).toEqual({
                         action          : 'replace',
                         startInBefore   : 0,
                         endInBefore     : 4,
@@ -152,11 +152,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have an insert at the beginning', function(){
-                    expect(res[0]).eql({
+                    expect(res[0]).toEqual({
                         action          : 'insert',
                         startInBefore   : 0,
                         endInBefore     : null,
@@ -174,11 +174,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have a delete at the beginning', function(){
-                    expect(res[0]).eql({
+                    expect(res[0]).toEqual({
                         action          : 'delete',
                         startInBefore   : 0,
                         endInBefore     : 1,
@@ -198,11 +198,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have a replace at the end', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'replace',
                         startInBefore   : 6,
                         endInBefore     : 8,
@@ -220,11 +220,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should return 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have an Insert at the end', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'insert',
                         startInBefore   : 7,
                         endInBefore     : null,
@@ -242,11 +242,11 @@ describe('calculateOperations', function(){
                 });
 
                 it('should have 2 operations', function(){
-                    expect(res.length).to.equal(2);
+                    expect(res.length).toBe(2);
                 });
 
                 it('should have a delete at the end', function(){
-                    expect(res[1]).eql({
+                    expect(res[1]).toEqual({
                         action          : 'delete',
                         startInBefore   : 7,
                         endInBefore     : 10,
@@ -267,11 +267,11 @@ describe('calculateOperations', function(){
             });
 
             it('should return 3 actions', function(){
-                expect(res.length).to.equal(1);
+                expect(res.length).toBe(1);
             });
 
             it('should have a replace first', function(){
-                expect(res[0].action).to.equal('replace');
+                expect(res[0].action).toBe('replace');
             });
         });
     });

--- a/test/config.js
+++ b/test/config.js
@@ -1,2 +1,0 @@
-var chai = require('chai');
-global.expect = chai.expect;

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -13,7 +13,7 @@ describe('Diff', function(){
       });
   
       it('should return the text', function(){
-        expect(res).equal('input text');
+        expect(res).toBe('input text');
       });
     }); // describe('When both inputs are the same')
   
@@ -23,27 +23,27 @@ describe('Diff', function(){
       });
   
       it('should mark the new letter', function(){
-        expect(res).to.equal('input<ins data-operation-index="1"> 2</ins>');
+        expect(res).toBe('input<ins data-operation-index="1"> 2</ins>');
       });
     }); // describe('When a letter is added')
   
     describe('Whitespace differences', function(){
       it('should collapse adjacent whitespace', function(){
-        expect(cut('Much \n\t    spaces', 'Much spaces')).to.equal('Much spaces');
+        expect(cut('Much \n\t    spaces', 'Much spaces')).toBe('Much spaces');
       });
   
       it('should consider non-breaking spaces as equal', function(){
-        expect(cut('Hello&nbsp;world', 'Hello&#160;world')).to.equal('Hello&#160;world');
+        expect(cut('Hello&nbsp;world', 'Hello&#160;world')).toBe('Hello&#160;world');
       });
   
       it('should consider non-breaking spaces and non-adjacent regular spaces as equal', function(){
-        expect(cut('Hello&nbsp;world', 'Hello world')).to.equal('Hello world');
+        expect(cut('Hello&nbsp;world', 'Hello world')).toBe('Hello world');
       });
     }); // describe('Whitespace differences')
   
     describe('When a class name is specified', function(){
       it('should include the class in the wrapper tags', function(){
-        expect(cut('input', 'input 2', 'diff-result')).to.equal(
+        expect(cut('input', 'input 2', 'diff-result')).toBe(
           'input<ins data-operation-index="1" class="diff-result"> 2</ins>');
       });
     }); // describe('When a class name is specified')
@@ -53,8 +53,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<img src="a.jpg">');
         var after = html_to_tokens('<img src="b.jpg">');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'replace',
           startInBefore: 0,
           endInBefore: 0,
@@ -67,8 +67,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<img src="a.jpg">');
         var after = html_to_tokens('<img src="a.jpg" alt="hey!">');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'equal',
           startInBefore: 0,
           endInBefore: 0,
@@ -83,8 +83,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<object data="a.jpg"></object>');
         var after = html_to_tokens('<object data="b.jpg"></object>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'replace',
           startInBefore: 0,
           endInBefore: 0,
@@ -97,8 +97,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<object data="a.jpg"><param>yo!</param></object>');
         var after = html_to_tokens('<object data="a.jpg"></object>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'equal',
           startInBefore: 0,
           endInBefore: 0,
@@ -115,8 +115,8 @@ describe('Diff', function(){
         var after = html_to_tokens('<math data-uuid="55784cd906504787a8e459e80e3bb554"><msqrt>' +
           '<msup><mn>b</mn><mn>5</mn></msup></msqrt></math>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'replace',
           startInBefore: 0,
           endInBefore: 0,
@@ -131,8 +131,8 @@ describe('Diff', function(){
         var after = html_to_tokens('<math data-uuid="55784cd906504787a8e459e80e3bb554"><msqrt>' +
           '<msup><mi>b</mi><mn>2</mn></msup></msqrt></math>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'equal',
           startInBefore: 0,
           endInBefore: 0,
@@ -149,8 +149,8 @@ describe('Diff', function(){
         var after = html_to_tokens('<video data-uuid="0787866ab5494d88b4b1ee423453224b">' +
           '<source src="inkling-video:///big_buck_rabbit/mp4" type="video/webm" /></video>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'replace',
           startInBefore: 0,
           endInBefore: 0,
@@ -166,8 +166,8 @@ describe('Diff', function(){
         var after = html_to_tokens('<video data-uuid="0787866ab5494d88b4b1ee423453224b">' +
           '<source src="inkling-video:///big_buck_bunny/webm_high" type="video/webm" /></video>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'equal',
           startInBefore: 0,
           endInBefore: 0,
@@ -182,8 +182,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<iframe src="a.jpg"></iframe>');
         var after = html_to_tokens('<iframe src="b.jpg"></iframe>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'replace',
           startInBefore: 0,
           endInBefore: 0,
@@ -196,8 +196,8 @@ describe('Diff', function(){
         var before = html_to_tokens('<iframe src="a.jpg"></iframe>');
         var after = html_to_tokens('<iframe src="a.jpg" class="foo"></iframe>');
         var ops = calculate_operations(before, after);
-        expect(ops.length).to.equal(1);
-        expect(ops[0]).to.eql({
+        expect(ops.length).toBe(1);
+        expect(ops[0]).toEqual({
           action: 'equal',
           startInBefore: 0,
           endInBefore: 0,

--- a/test/find_matching_blocks.spec.js
+++ b/test/find_matching_blocks.spec.js
@@ -19,7 +19,7 @@ describe('findMatchingBlocks', function(){
         });
 
         it('should be a function', function(){
-            expect(cut).is.a('function');
+            expect(typeof cut).toBe('function');
         });
 
         describe('When the items exist in the search target', function(){
@@ -28,19 +28,19 @@ describe('findMatchingBlocks', function(){
             });
 
             it('should find "a" twice', function(){
-                expect(res['a'].length).to.equal(2);
+                expect(res['a'].length).toBe(2);
             });
 
             it('should find "a" at 0', function(){
-                expect(res['a'][0]).to.equal(0);
+                expect(res['a'][0]).toBe(0);
             });
 
             it('should find "a" at 3', function(){
-                expect(res['a'][1]).to.equal(3);
+                expect(res['a'][1]).toBe(3);
             });
 
             it('should find "has" at 2', function(){
-                expect(res['has'][0]).to.equal(2);
+                expect(res['has'][0]).toBe(2);
             });
         });
     });
@@ -65,12 +65,12 @@ describe('findMatchingBlocks', function(){
             });
 
             it('should match the match', function(){
-                expect(res).to.exist;
-                expect(res.startInBefore).equal(0);
-                expect(res.startInAfter).equal(0);
-                expect(res.length).equal(3);
-                expect(res.endInBefore).equal(2);
-                expect(res.endInAfter).equal(2);
+                expect(res).toBeDefined();
+                expect(res.startInBefore).toBe(0);
+                expect(res.startInAfter).toBe(0);
+                expect(res.length).toBe(3);
+                expect(res.endInBefore).toBe(2);
+                expect(res.endInAfter).toBe(2);
             });
 
             describe('When the match is surrounded', function(){
@@ -81,11 +81,11 @@ describe('findMatchingBlocks', function(){
                 });
 
                 it('should match with appropriate indexing', function(){
-                    expect(res).to.exist;
-                    expect(res.startInBefore).to.equal(0);
-                    expect(res.startInAfter).to.equal(1);
-                    expect(res.endInBefore).to.equal(1);
-                    expect(res.endInAfter).to.equal(2);
+                    expect(res).toBeDefined();
+                    expect(res.startInBefore).toBe(0);
+                    expect(res.startInAfter).toBe(1);
+                    expect(res.endInBefore).toBe(1);
+                    expect(res.endInAfter).toBe(2);
                 });
             });
         });
@@ -98,7 +98,7 @@ describe('findMatchingBlocks', function(){
             });
 
             it('should return nothing', function(){
-                expect(res).to.not.exist;
+                expect(res).toBeUndefined();
             });
         });
     });
@@ -111,7 +111,7 @@ describe('findMatchingBlocks', function(){
         });
 
         it('should be a function', function(){
-            expect(cut).is.a('function');
+            expect(typeof cut).toBe('function');
         });
 
         describe('When called with a single match', function(){
@@ -124,7 +124,7 @@ describe('findMatchingBlocks', function(){
             });
 
             it('should return a match', function(){
-                expect(res.length).to.equal(1);
+                expect(res.length).toBe(1);
             });
         });
 
@@ -137,31 +137,31 @@ describe('findMatchingBlocks', function(){
             });
 
             it('should return 3 matches', function(){
-                expect(res.length).to.equal(3);
+                expect(res.length).toBe(3);
             });
 
             it('should match "the"', function(){
-                expect(res[0].startInBefore).eql(0);
-                expect(res[0].startInAfter).eql(0);
-                expect(res[0].endInBefore).eql(0);
-                expect(res[0].endInAfter).eql(0);
-                expect(res[0].length).eql(1);
+                expect(res[0].startInBefore).toBe(0);
+                expect(res[0].startInAfter).toBe(0);
+                expect(res[0].endInBefore).toBe(0);
+                expect(res[0].endInAfter).toBe(0);
+                expect(res[0].length).toBe(1);
             });
 
             it('should match "dog bit a"', function(){
-                expect(res[1].startInBefore).eql(1);
-                expect(res[1].startInAfter).eql(5);
-                expect(res[1].endInBefore).eql(7);
-                expect(res[1].endInAfter).eql(11);
-                expect(res[1].length).eql(7);
+                expect(res[1].startInBefore).toBe(1);
+                expect(res[1].startInAfter).toBe(5);
+                expect(res[1].endInBefore).toBe(7);
+                expect(res[1].endInAfter).toBe(11);
+                expect(res[1].length).toBe(7);
             });
 
             it('should match "man"', function(){
-                expect(res[2].startInBefore).eql(8);
-                expect(res[2].startInAfter).eql(14);
-                expect(res[2].endInBefore).eql(8);
-                expect(res[2].endInAfter).eql(14);
-                expect(res[2].length).eql(1);
+                expect(res[2].startInBefore).toBe(8);
+                expect(res[2].startInAfter).toBe(14);
+                expect(res[2].endInBefore).toBe(8);
+                expect(res[2].endInAfter).toBe(14);
+                expect(res[2].length).toBe(1);
             });
         });
     });

--- a/test/from_port_source.spec.js
+++ b/test/from_port_source.spec.js
@@ -7,24 +7,24 @@ describe('The specs from the ruby source project', function(){
 
     it('should diff text', function(){
         var diff = cut('a word is here', 'a nother word is there');
-        expect(diff).equal('a<ins data-operation-index="1"> nother</ins> word is ' +
+        expect(diff).toBe('a<ins data-operation-index="1"> nother</ins> word is ' +
                 '<del data-operation-index="3">here</del><ins data-operation-index="3">' +
                 'there</ins>');
     });
 
     it('should insert a letter and a space', function(){
         var diff = cut('a c', 'a b c');
-        expect(diff).equal('a <ins data-operation-index="1">b </ins>c');
+        expect(diff).toBe('a <ins data-operation-index="1">b </ins>c');
     });
 
     it('should remove a letter and a space', function(){
         var diff = cut('a b c', 'a c');
-        diff.should == 'a <del data-operation-index="1">b </del>c';
+        expect(diff).toBe('a <del data-operation-index="1">b </del>c');
     });
 
     it('should change a letter', function(){
         var diff = cut('a b c', 'a d c');
-        expect(diff).equal('a <del data-operation-index="1">b</del>' +
+        expect(diff).toBe('a <del data-operation-index="1">b</del>' +
                 '<ins data-operation-index="1">d</ins> c');
     });
 });

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -14,7 +14,7 @@ describe('htmlToTokens', function(){
     });
 
     it('should be a function', function(){
-        expect(cut).is.a('function');
+        expect(typeof cut).toBe('function');
     });
 
     describe('when called with text', function(){
@@ -23,7 +23,7 @@ describe('htmlToTokens', function(){
         });
 
         it('should return 4', function(){
-            expect(res.length).to.equal(7);
+            expect(res.length).toBe(7);
         });
     });
 
@@ -33,36 +33,36 @@ describe('htmlToTokens', function(){
         });
 
         it('should return 11', function(){
-            expect(res.length).to.equal(11);
+            expect(res.length).toBe(11);
         });
 
         it('should remove any html comments', function(){
             res = cut('<p> this is <!-- a comment! --> </p>');
-            expect(res.length).to.equal(8);
+            expect(res.length).toBe(8);
         });
     });
 
     it('should identify contiguous whitespace as a single token', function(){
-        expect(cut('a   b')).to.eql(tokenize(['a', '   ', 'b']));
+        expect(cut('a   b')).toEqual(tokenize(['a', '   ', 'b']));
     });
 
     it('should identify a single space as a single token', function(){
-        expect(cut(' a b ')).to.eql(tokenize([' ', 'a', ' ', 'b', ' ']));
+        expect(cut(' a b ')).toEqual(tokenize([' ', 'a', ' ', 'b', ' ']));
     });
 
     it('should identify self closing tags as tokens', function(){
-        expect(cut('<p>hello</br>goodbye</p>')).eql(
+        expect(cut('<p>hello</br>goodbye</p>')).toEqual(
                 tokenize(['<p>', 'hello', '</br>', 'goodbye', '</p>']));
     });
 
     describe('when encountering atomic tags', function(){
         it('should identify an image tag as a single token', function(){
-            expect(cut('<p><img src="1.jpg"><img src="2.jpg"></p>')).eql(
+            expect(cut('<p><img src="1.jpg"><img src="2.jpg"></p>')).toEqual(
                     tokenize(['<p>', '<img src="1.jpg">', '<img src="2.jpg">', '</p>']));
         });
 
         it('should identify an iframe tag as a single token', function(){
-            expect(cut('<p><iframe src="sample.html"></iframe></p>')).eql(
+            expect(cut('<p><iframe src="sample.html"></iframe></p>')).toEqual(
                     tokenize(['<p>', '<iframe src="sample.html"></iframe>', '</p>']));
         });
 
@@ -70,7 +70,7 @@ describe('htmlToTokens', function(){
             var cutResult = cut('<p><object><param name="1" /><param name="2" /></object></p>');
             var tokenizeResult = tokenize(
                     ['<p>', '<object><param name="1" /><param name="2" /></object>','</p>']);
-            expect(cutResult).eql(tokenizeResult);
+            expect(cutResult).toEqual(tokenizeResult);
         });
 
         it('should identify a math tag as a single token', function(){
@@ -86,7 +86,7 @@ describe('htmlToTokens', function(){
                 '<msup><mi>r</mi><mn>2</mn></msup></math>',
                 '</p>'
             ]);
-            expect(cutResult).eql(tokenizeResult);
+            expect(cutResult).toEqual(tokenizeResult);
         });
 
         it('should identify an svg tag as a single token', function(){
@@ -100,11 +100,11 @@ describe('htmlToTokens', function(){
                 '</svg>',
                 '</p>'
             ]);
-            expect(cutResult).eql(tokenizeResult);
+            expect(cutResult).toEqual(tokenizeResult);
         });
 
         it('should identify a script tag as a single token', function(){
-            expect(cut('<p><script>console.log("hi");</script></p>')).eql(
+            expect(cut('<p><script>console.log("hi");</script></p>')).toEqual(
                     tokenize(['<p>', '<script>console.log("hi");</script>', '</p>']));
         });
     });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---require test/config.js
---ui bdd
---reporter spec

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -6,6 +6,6 @@ describe('The module', function(){
     });
 
     it('should return a function', function(){
-        expect(cut).is.a('function');
+        expect(typeof cut).toBe('function');
     });
 });

--- a/test/pain_games.spec.js
+++ b/test/pain_games.spec.js
@@ -11,7 +11,7 @@ describe('Pain Games', function(){
         });
 
         it('should replace the whole chunk', function(){
-            expect(res).to.equal('<del data-operation-index="0">this is what I had</del>' +
+            expect(res).toBe('<del data-operation-index="0">this is what I had</del>' +
                     '<ins data-operation-index="0">and now we have a new one</ins>');
         });
     });

--- a/test/render_operations.spec.js
+++ b/test/render_operations.spec.js
@@ -28,7 +28,7 @@ describe('renderOperations', function(){
         });
 
         it('should output the text', function(){
-            expect(res).equal('this is a test');
+            expect(res).toBe('this is a test');
         });
     });
 
@@ -40,7 +40,7 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in an <ins>', function(){
-            expect(res).equal('this is<ins data-operation-index="1"> a test</ins>');
+            expect(res).toBe('this is<ins data-operation-index="1"> a test</ins>');
         });
     });
 
@@ -53,7 +53,7 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in a <del>', function(){
-            expect(res).to.equal('this is a test<del data-operation-index="1"> of stuff</del>');
+            expect(res).toBe('this is a test<del data-operation-index="1"> of stuff</del>');
         });
     });
 
@@ -65,7 +65,7 @@ describe('renderOperations', function(){
         });
 
         it('should wrap in both <ins> and <del>', function(){
-            expect(res).to.equal('this is a <del data-operation-index="1">break</del>' +
+            expect(res).toBe('this is a <del data-operation-index="1">break</del>' +
                     '<ins data-operation-index="1">test</ins>');
         });
     });
@@ -80,7 +80,7 @@ describe('renderOperations', function(){
         });
 
         it('should identify contained inserted tags', function(){
-            expect(res).to.equal('<p>a<ins data-operation-index="1"> b</ins></p>' +
+            expect(res).toBe('<p>a<ins data-operation-index="1"> b</ins></p>' +
                     '<p data-diff-node="ins" data-operation-index="3">' +
                     '<ins data-operation-index="3">c</ins></p>');
         });
@@ -88,7 +88,7 @@ describe('renderOperations', function(){
         it('should identify contained deleted tags', function(){
             res = cut(after, before);
 
-            expect(res).to.equal('<p>a<del data-operation-index="1"> b</del></p>' +
+            expect(res).toBe('<p>a<del data-operation-index="1"> b</del></p>' +
                     '<p data-diff-node="del" data-operation-index="3">' +
                     '<del data-operation-index="3">c</del></p>');
         });
@@ -98,7 +98,7 @@ describe('renderOperations', function(){
             var after = tokenize(['test!', '</b>', 'non-bold', '<b>', 'bold']);
             res = cut(before, after);
 
-            expect(res).to.equal('<del data-operation-index="0">test</del>' +
+            expect(res).toBe('<del data-operation-index="0">test</del>' +
                     '<ins data-operation-index="0">test!</ins></b>non-bold<b>' +
                     '<ins data-operation-index="2">bold</ins>');
         });
@@ -111,7 +111,7 @@ describe('renderOperations', function(){
             });
 
             it('should keep the change inside the <p>', function(){
-                expect(res).to.equal('<p><del data-operation-index="1">this</del>' +
+                expect(res).toBe('<p><del data-operation-index="1">this</del>' +
                         '<ins data-operation-index="1">I</ins> is awesome</p>');
             });
         });
@@ -124,7 +124,7 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal('text');
+            expect(res).toBe('text');
         });
     });
 
@@ -136,7 +136,7 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal('<p style="margin: 2px;" class="after">this is awesome</p>');
+            expect(res).toBe('<p style="margin: 2px;" class="after">this is awesome</p>');
         });
 
         it('should show changes within tags with different attributes', function(){
@@ -146,7 +146,7 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal('<p style="margin: 2px;" class="after">' +
+            expect(res).toBe('<p style="margin: 2px;" class="after">' +
                     '<del data-operation-index="1">this</del><ins data-operation-index="1">' +
                     'that</ins> is awesome</p>');
         });
@@ -159,7 +159,7 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal('<del data-operation-index="0">old</del>' +
+            expect(res).toBe('<del data-operation-index="0">old</del>' +
                     '<ins data-operation-index="0">new<br/></ins> text');
         });
 
@@ -169,7 +169,7 @@ describe('renderOperations', function(){
 
             res = cut(before, after);
 
-            expect(res).to.equal(
+            expect(res).toBe(
                     '<del data-operation-index="0">old<iframe src="source.html"></iframe></del>' +
                     '<ins data-operation-index="0">new</ins> text');
         });


### PR DESCRIPTION
## Summary
- remove Mocha/Chai and use Jest instead
- update tests to Jest expectations
- delete obsolete Mocha config files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416e488cd8832ebe457c0a07ba7776