### PR TITLE
Initialize atomic tag regex at module load

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -68,9 +68,9 @@
      * Regular expression to check atomic tags.
      * @see function diff.
      */
-    var atomicTagsRegExp;
     // Added head and style (for style tags inside the body)
     var defaultAtomicTagsRegExp = new RegExp('^<(iframe|object|math|svg|script|video|head|style|a)\b');
+    var atomicTagsRegExp = defaultAtomicTagsRegExp;
     
     /**
      * Checks if the current word is the beginning of an atomic tag. An atomic tag is one whose
@@ -171,6 +171,9 @@
      * @return {Array.<string>} The list of tokens.
      */
     function htmlToTokens(html){
+        if (!atomicTagsRegExp) {
+            atomicTagsRegExp = defaultAtomicTagsRegExp;
+        }
         var mode = 'char';
         var currentWord = '';
         var currentAtomicTag = '';


### PR DESCRIPTION
## Summary
- initialize `atomicTagsRegExp` with the default regex when the module loads
- guard `htmlToTokens` against a missing `atomicTagsRegExp`
- run `npm test`

## Testing
- `npm install`
- `npm test` *(fails: some tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6841a2be8e4c832e892ba2a179b90ad7